### PR TITLE
Summer 2017 - Unit paths show on hover fix 2

### DIFF
--- a/Assets/UI/worldinput.lua
+++ b/Assets/UI/worldinput.lua
@@ -747,16 +747,17 @@ function RealizeMovementPath(showQueuedPath:boolean, CQUI_HoveredUnit)
   end
 
   -- Bail if no selected unit.
-  local kUnit :table = UI.GetHeadSelectedUnit();
+  local kUnit :table = nil;
+  if CQUI_HoveredUnit then
+    kUnit = CQUI_HoveredUnit;
+  else
+    kUnit = UI.GetHeadSelectedUnit();
+  end
   if kUnit == nil then
     UILens.SetActive("Default");
     m_cachedPathUnit = nil;
     m_cachedPathPlotId = -1;
-    if CQUI_HoveredUnit then
-      kUnit = CQUI_HoveredUnit;
-    else
-      return;
-    end
+    return;
   end
 
   -- Bail if unit is not a type that allows movement.
@@ -766,9 +767,6 @@ function RealizeMovementPath(showQueuedPath:boolean, CQUI_HoveredUnit)
 
   -- Bail if end plot is not determined.
   local endPlotId :number = UI.GetCursorPlotID();
-  if CQUI_HoveredUnit then
-    endPlotId = -1;
-  end
 
 	-- Use the queued destinationt o show the queued path
 	if (showQueuedPath) then
@@ -792,10 +790,9 @@ function RealizeMovementPath(showQueuedPath:boolean, CQUI_HoveredUnit)
       UILens.UnFocusHex( LensLayers.ATTACK_RANGE, m_cachedPathPlotId );
     end
 
-    if not CQUI_HoveredUnit then
-      m_cachedPathUnit  = kUnit;
-      m_cachedPathPlotId  = endPlotId;
-    end
+    m_cachedPathUnit  = kUnit;
+    m_cachedPathPlotId  = endPlotId;
+
 
     -- Obtain ordered list of plots.
     local turnsList   : table;
@@ -3770,7 +3767,8 @@ function Initialize()
   -- CQUI Events
   LuaEvents.CQUI_WorldInput_CityviewEnable.Add( function() CQUI_cityview = true; end );
   LuaEvents.CQUI_WorldInput_CityviewDisable.Add( function() CQUI_cityview = false; end );
-  LuaEvents.CQUI_RealizeMovementPathOnHover.Add( RealizeMovementPath );
+  LuaEvents.CQUI_ShowPathOnHover.Add( RealizeMovementPath );
+  LuaEvents.CQUI_HidePathOnHover.Add( ClearMovementPath );
 
   Controls.DebugStuff:SetHide(not m_isDebuging);
   -- Popup setup


### PR DESCRIPTION
I have no idea why but an issue appeared in Summer-2017 patch when function UnitFlag.SetInteractivity() didn't update unitID for CQUI_ShowPath() function after a unit was upgraded. In that case we couldn't see paths when hover upgraded units. To fix this we add a table with unitIDs and take values from there when units are upgraded.
Also added some tweaks to a previous commit.