### PR TITLE
Summer 2017 - Unit paths show on hover fix

### DIFF
--- a/Assets/UI/worldinput.lua
+++ b/Assets/UI/worldinput.lua
@@ -739,14 +739,20 @@ end
 -- ===========================================================================
 --  Update the 3D displayed path for a unit.
 -- ===========================================================================
-function RealizeMovementPath(showQueuedPath:boolean)
+--CQUI modifications for showing unit paths on hover
+function RealizeMovementPath(showQueuedPath:boolean, CQUI_HoveredUnit)
 
   if not UI.IsMovementPathOn() or UI.IsGameCoreBusy() then
     return;
   end
 
   -- Bail if no selected unit.
-  local kUnit :table = UI.GetHeadSelectedUnit();
+  local kUnit :table = nil;
+  if CQUI_HoveredUnit then
+    kUnit = CQUI_HoveredUnit;
+  else
+    kUnit = UI.GetHeadSelectedUnit();
+  end
   if kUnit == nil then
     UILens.SetActive("Default");
     m_cachedPathUnit = nil;
@@ -3761,6 +3767,8 @@ function Initialize()
   -- CQUI Events
   LuaEvents.CQUI_WorldInput_CityviewEnable.Add( function() CQUI_cityview = true; end );
   LuaEvents.CQUI_WorldInput_CityviewDisable.Add( function() CQUI_cityview = false; end );
+  LuaEvents.CQUI_ShowPathOnHover.Add( RealizeMovementPath );
+  LuaEvents.CQUI_HidePathOnHover.Add( ClearMovementPath );
 
   Controls.DebugStuff:SetHide(not m_isDebuging);
   -- Popup setup


### PR DESCRIPTION
As soon as devs added queued paths for selected units and because of trade layer paths became thicker I removed a part of CQUI code showing paths on selection and I left showing paths on hover only. Now to show and hide unit paths on hover we use the same layers and the same functions as vanilla does when a unit is selected/deselected.
I have no idea why but an issue appeared in Summer-2017 patch when function UnitFlag.SetInteractivity() didn't update unitID for CQUI_ShowPath() function after a unit was upgraded. In that case we couldn't see paths when hover upgraded units. To fix this we add a table with unitIDs and take values from there when units are upgraded.